### PR TITLE
Fix: Install Terrform Error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,10 @@ commands:
           name: "Download the Terraform ZIP"
           command: wget https://releases.hashicorp.com/terraform/0.12.19/terraform_0.12.19_linux_amd64.zip
       - run:
-          name: "Unzip terraform_0.12.19_linux_amd64.zip and move to /usr/local/bin"
-          command: unzip ./terraform_0.12.19_linux_amd64.zip –d /usr/local/bin
+          name: "Unzip terraform_0.12.19_linux_amd64.zip and move to /usr/bin"
+          command: |
+            unzip terraform_0.12.19_linux_amd64.zip
+            mv terraform /usr/bin
       - run:
           name: "Show the Terraform version"
           command: terraform -v


### PR DESCRIPTION
# Fix: Install Terrform Error

Closes alxmedium/alxmedium#29

## Description

Fix the installation error when tries to move to terraform the bin directory

## Checklist

- [ ] Passed all the linter evaluations
- [ ] Passed all the tests
- [ ] Update documentation
- [ ] Add environment variables
- [ ] Update environment variables
- [x] Update the **CircleCI** configuration
- [ ] Update the **NPM scripts**
- [ ] Update the **Makefile scripts**
- [ ] Update the **Infrastructure**
- [ ] Update **Pip** packages
- [ ] Update **NPM** packages
- [ ] Add **Pip** packages
- [ ] Add **NPM** packages

## Changes

