### PR TITLE
CircleCI AWS User

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,10 @@ jobs:
       - setup_terraform
       - run:
           name: "Show the Infrastructure Plan"
-          command: terraform plan
+          command: |
+            terraform plan \
+            -var aws_access_key_id=$AWS_ACCESS_KEY_ID \
+            -var aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
   apply:
     executor: ubuntu
     steps:

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,83 @@ variable "aws_secret_access_key" {
   type = string
 }
 
-
 provider "aws" {
   access_key = var.aws_access_key_id
   secret_key = var.aws_secret_access_key
   region     = "us-east-1"
   version    = "2.47.0"
+}
+
+resource "aws_iam_user" "alxmedium_circleci_iam_user" {
+  name = "alxmedium_circleci_iam_user"
+  path = "/"
+}
+
+resource "aws_iam_access_key" "alxmedium_circleci_iam_access_key" {
+  user = aws_iam_user.alxmedium_circleci_iam_user.name
+}
+
+resource "aws_iam_user_policy" "alxmedium_circleci_iam_user_policy" {
+  name   = "alxmedium_circleci_iam_user_policy"
+  user   = aws_iam_user.alxmedium_circleci_iam_user.name
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:GenerateCredentialReport",
+                "iam:GenerateServiceLastAccessedDetails",
+                "iam:Get*",
+                "iam:List*",
+                "iam:SimulateCustomPolicy",
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeRouteTables",
+                "ec2:CreateRoute",
+                "ec2:DeleteRoute",
+                "ec2:ReplaceRoute"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:CreateNetworkInterface",
+                "ec2:DeleteNetworkInterface",
+                "ec2:CreateNetworkInterfacePermission",
+                "ec2:DeleteNetworkInterfacePermission",
+                "ec2:DescribeNetworkInterfacePermissions",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ec2:DescribeNetworkInterfaceAttribute",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSubnets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AssignPrivateIpAddresses",
+                "ec2:UnassignPrivateIpAddresses"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+  EOF
 }

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,8 +1,78 @@
 {
   "version": 4,
   "terraform_version": "0.12.19",
-  "serial": 1,
+  "serial": 21,
   "lineage": "dbe885c0-c748-8ca0-533b-3fc0189ecba4",
   "outputs": {},
-  "resources": []
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_iam_access_key",
+      "name": "alxmedium_circleci_iam_access_key",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "encrypted_secret": null,
+            "id": "AKIAT2OALSJCSO2KFA7V",
+            "key_fingerprint": null,
+            "pgp_key": null,
+            "secret": "1S03DiAPQdOS+TrBK2/mesOPZ60uuk+wzOe0azXB",
+            "ses_smtp_password": "AtGoisRAlc9zqZUeHCJ8C99B5LMA+ps15mrCLhjCuQqG",
+            "status": "Active",
+            "user": "alxmedium_circleci_iam_user"
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_iam_user.alxmedium_circleci_iam_user"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "alxmedium_circleci_iam_user",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::262933287493:user/alxmedium_circleci_iam_user",
+            "force_destroy": false,
+            "id": "alxmedium_circleci_iam_user",
+            "name": "alxmedium_circleci_iam_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": null,
+            "unique_id": "AIDAT2OALSJC6KHPZOV6X"
+          },
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_user_policy",
+      "name": "alxmedium_circleci_iam_user_policy",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "alxmedium_circleci_iam_user:alxmedium_circleci_iam_user_policy",
+            "name": "alxmedium_circleci_iam_user_policy",
+            "name_prefix": null,
+            "policy": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:DescribeRouteTables\",\n                \"ec2:CreateRoute\",\n                \"ec2:DeleteRoute\",\n                \"ec2:ReplaceRoute\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DeleteNetworkInterface\",\n                \"ec2:CreateNetworkInterfacePermission\",\n                \"ec2:DeleteNetworkInterfacePermission\",\n                \"ec2:DescribeNetworkInterfacePermissions\",\n                \"ec2:ModifyNetworkInterfaceAttribute\",\n                \"ec2:DescribeNetworkInterfaceAttribute\",\n                \"ec2:DescribeAvailabilityZones\",\n                \"ec2:DescribeVpcs\",\n                \"ec2:DescribeSubnets\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:AssignPrivateIpAddresses\",\n                \"ec2:UnassignPrivateIpAddresses\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        }\n    ]\n}\n",
+            "user": "alxmedium_circleci_iam_user"
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_iam_user.alxmedium_circleci_iam_user"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/terraform.tfstate.backup
+++ b/terraform.tfstate.backup
@@ -1,0 +1,8 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.19",
+  "serial": 17,
+  "lineage": "dbe885c0-c748-8ca0-533b-3fc0189ecba4",
+  "outputs": {},
+  "resources": []
+}


### PR DESCRIPTION
# CircleCI AWS User

Closes alxmedium/alxmedium#31

## Description

Add an **AWS User** for **CircleCI** with the accesses to apply the infrastructure described in the **Terraform** files.

## Checklist

- [x] Passed all the linter evaluations
- [x] Passed all the tests
- [ ] Update documentation
- [ ] Add environment variables
- [ ] Update environment variables
- [x] Update the **CircleCI** configuration
- [ ] Update the **NPM scripts**
- [ ] Update the **Makefile scripts**
- [x] Update the **Infrastructure**
- [ ] Update **Pip** packages
- [ ] Update **NPM** packages
- [ ] Add **Pip** packages
- [ ] Add **NPM** packages

## Changes

- Add read-only access to the **IAM** resource to the **alxmedium_circleci_iam_user**
- Add full network access to the **VPC** resource to the **alxmedium_circleci_iam_user**
- Resolve the issue in the **CircleCI** configuration to run the **plan** job