### PR TITLE
Apply Infrastructure Plan with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
           name: "Apply the Infrastructure Plan"
           command: |
             terraform apply \
+            -auto-approve \
             -var aws_access_key_id=$AWS_ACCESS_KEY_ID \
             -var aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
 

--- a/main.tf
+++ b/main.tf
@@ -14,16 +14,12 @@ provider "aws" {
 }
 
 resource "aws_iam_user" "alxmedium_circleci_iam_user" {
-  name = "alxmedium_circleci_iam_user"
+  name = "alxmedium_circleci"
   path = "/"
 }
 
-resource "aws_iam_access_key" "alxmedium_circleci_iam_access_key" {
-  user = aws_iam_user.alxmedium_circleci_iam_user.name
-}
-
 resource "aws_iam_user_policy" "alxmedium_circleci_iam_user_policy" {
-  name   = "alxmedium_circleci_iam_user_policy"
+  name   = "alxmedium_circleci"
   user   = aws_iam_user.alxmedium_circleci_iam_user.name
   policy = <<EOF
 {
@@ -32,55 +28,10 @@ resource "aws_iam_user_policy" "alxmedium_circleci_iam_user_policy" {
         {
             "Effect": "Allow",
             "Action": [
-                "iam:GenerateCredentialReport",
-                "iam:GenerateServiceLastAccessedDetails",
                 "iam:Get*",
-                "iam:List*",
-                "iam:SimulateCustomPolicy",
-                "iam:SimulatePrincipalPolicy"
+                "iam:PutUserPolicy*"
             ],
             "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeRouteTables",
-                "ec2:CreateRoute",
-                "ec2:DeleteRoute",
-                "ec2:ReplaceRoute"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:CreateNetworkInterface",
-                "ec2:DeleteNetworkInterface",
-                "ec2:CreateNetworkInterfacePermission",
-                "ec2:DeleteNetworkInterfacePermission",
-                "ec2:DescribeNetworkInterfacePermissions",
-                "ec2:ModifyNetworkInterfaceAttribute",
-                "ec2:DescribeNetworkInterfaceAttribute",
-                "ec2:DescribeAvailabilityZones",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeSubnets"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AssignPrivateIpAddresses",
-                "ec2:UnassignPrivateIpAddresses"
-            ],
-            "Resource": [
-                "*"
-            ]
         }
     ]
 }

--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,35 +1,10 @@
 {
   "version": 4,
   "terraform_version": "0.12.19",
-  "serial": 21,
+  "serial": 24,
   "lineage": "dbe885c0-c748-8ca0-533b-3fc0189ecba4",
   "outputs": {},
   "resources": [
-    {
-      "mode": "managed",
-      "type": "aws_iam_access_key",
-      "name": "alxmedium_circleci_iam_access_key",
-      "provider": "provider.aws",
-      "instances": [
-        {
-          "schema_version": 0,
-          "attributes": {
-            "encrypted_secret": null,
-            "id": "AKIAT2OALSJCSO2KFA7V",
-            "key_fingerprint": null,
-            "pgp_key": null,
-            "secret": "1S03DiAPQdOS+TrBK2/mesOPZ60uuk+wzOe0azXB",
-            "ses_smtp_password": "AtGoisRAlc9zqZUeHCJ8C99B5LMA+ps15mrCLhjCuQqG",
-            "status": "Active",
-            "user": "alxmedium_circleci_iam_user"
-          },
-          "private": "bnVsbA==",
-          "dependencies": [
-            "aws_iam_user.alxmedium_circleci_iam_user"
-          ]
-        }
-      ]
-    },
     {
       "mode": "managed",
       "type": "aws_iam_user",
@@ -45,7 +20,7 @@
             "name": "alxmedium_circleci_iam_user",
             "path": "/",
             "permissions_boundary": null,
-            "tags": null,
+            "tags": {},
             "unique_id": "AIDAT2OALSJC6KHPZOV6X"
           },
           "private": "bnVsbA=="
@@ -64,7 +39,7 @@
             "id": "alxmedium_circleci_iam_user:alxmedium_circleci_iam_user_policy",
             "name": "alxmedium_circleci_iam_user_policy",
             "name_prefix": null,
-            "policy": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:DescribeRouteTables\",\n                \"ec2:CreateRoute\",\n                \"ec2:DeleteRoute\",\n                \"ec2:ReplaceRoute\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DeleteNetworkInterface\",\n                \"ec2:CreateNetworkInterfacePermission\",\n                \"ec2:DeleteNetworkInterfacePermission\",\n                \"ec2:DescribeNetworkInterfacePermissions\",\n                \"ec2:ModifyNetworkInterfaceAttribute\",\n                \"ec2:DescribeNetworkInterfaceAttribute\",\n                \"ec2:DescribeAvailabilityZones\",\n                \"ec2:DescribeVpcs\",\n                \"ec2:DescribeSubnets\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:AssignPrivateIpAddresses\",\n                \"ec2:UnassignPrivateIpAddresses\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        }\n    ]\n}\n",
+            "policy": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"iam:Get*\",\n                \"iam:PutUserPolicy*\"\n            ],\n            \"Resource\": \"*\"\n        }\n    ]\n}",
             "user": "alxmedium_circleci_iam_user"
           },
           "private": "bnVsbA==",

--- a/terraform.tfstate.backup
+++ b/terraform.tfstate.backup
@@ -1,8 +1,53 @@
 {
   "version": 4,
   "terraform_version": "0.12.19",
-  "serial": 17,
+  "serial": 23,
   "lineage": "dbe885c0-c748-8ca0-533b-3fc0189ecba4",
   "outputs": {},
-  "resources": []
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_iam_user",
+      "name": "alxmedium_circleci_iam_user",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:iam::262933287493:user/alxmedium_circleci_iam_user",
+            "force_destroy": false,
+            "id": "alxmedium_circleci_iam_user",
+            "name": "alxmedium_circleci_iam_user",
+            "path": "/",
+            "permissions_boundary": null,
+            "tags": {},
+            "unique_id": "AIDAT2OALSJC6KHPZOV6X"
+          },
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_iam_user_policy",
+      "name": "alxmedium_circleci_iam_user_policy",
+      "provider": "provider.aws",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "alxmedium_circleci_iam_user:alxmedium_circleci_iam_user_policy",
+            "name": "alxmedium_circleci_iam_user_policy",
+            "name_prefix": null,
+            "policy": "{\n    \"Version\": \"2012-10-17\",\n    \"Statement\": [\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"iam:Get*\",\n                \"iam:PutUserPolicy*\"\n            ],\n            \"Resource\": \"*\"\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:DescribeRouteTables\",\n                \"ec2:CreateRoute\",\n                \"ec2:DeleteRoute\",\n                \"ec2:ReplaceRoute\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:DescribeNetworkInterfaces\",\n                \"ec2:CreateNetworkInterface\",\n                \"ec2:DeleteNetworkInterface\",\n                \"ec2:CreateNetworkInterfacePermission\",\n                \"ec2:DeleteNetworkInterfacePermission\",\n                \"ec2:DescribeNetworkInterfacePermissions\",\n                \"ec2:ModifyNetworkInterfaceAttribute\",\n                \"ec2:DescribeNetworkInterfaceAttribute\",\n                \"ec2:DescribeAvailabilityZones\",\n                \"ec2:DescribeVpcs\",\n                \"ec2:DescribeSubnets\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        },\n        {\n            \"Effect\": \"Allow\",\n            \"Action\": [\n                \"ec2:AssignPrivateIpAddresses\",\n                \"ec2:UnassignPrivateIpAddresses\"\n            ],\n            \"Resource\": [\n                \"*\"\n            ]\n        }\n    ]\n}\n",
+            "user": "alxmedium_circleci_iam_user"
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_iam_user.alxmedium_circleci_iam_user"
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
# Apply Infrastructure Plan with CircleCI

Closes alxmedium/alxmedium#33

## Description

Solved the issues that stopped the **apply** job in the **CircleCI** workflow

## Checklist

- [x] Passed all the linter evaluations
- [ ] Passed all the tests
- [ ] Update documentation
- [ ] Add environment variables
- [ ] Update environment variables
- [x] Update the **CircleCI** configuration
- [ ] Update the **NPM scripts**
- [ ] Update the **Makefile scripts**
- [x] Update the **Infrastructure**
- [ ] Update **Pip** packages
- [ ] Update **NPM** packages
- [ ] Add **Pip** packages
- [ ] Add **NPM** packages

## Changes

- Rename **alxmedium_circleci_iam_user** and **alxmedium_circleci_iam_user_policy** resources
- Add `-auto-approve` flag to apply the **Terraform Plan** without confirmation in the **apply** job
- Delete the **alxmedium_circleci_iam_access_key** resource
- Remove the unnecessary accesses of the **alxmedium_circleci_iam_user_policy**